### PR TITLE
Update subgroup retrieval comment

### DIFF
--- a/Get-AzureADSubgroupUsers.ps1
+++ b/Get-AzureADSubgroupUsers.ps1
@@ -7,7 +7,7 @@ $group = Get-AzureADGroup -SearchString "GROUPNAME"
 # Create an empty array to store the results
 $results = @()
 
-# Get All Groups in the Group
+# Get all subgroups within the specified group
 $groups = Get-AzureADGroupMember -ObjectId $group.ObjectId -All $true | Where-Object { $_.ObjectType -eq 'Group' }
 
 # Loop through each group


### PR DESCRIPTION
## Summary
- update comment describing subgroup retrieval logic

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407c2fb51083278100135a20e9859c