### PR TITLE
Fix README license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The script creates a CSV file containing two columns: `GroupDisplayName` and `Us
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- fix the README hyperlink to the LICENSE file

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68407c1b5b3483278ee6017560f071ca